### PR TITLE
add Makefile support for call alias and actor name

### DIFF
--- a/actor/echo/Makefile
+++ b/actor/echo/Makefile
@@ -10,5 +10,10 @@ REG_URL  = localhost:5000/v2/$(PROJECT):$(VERSION)
 # command to upload to registry (without last wasm parameter)
 PUSH_REG_CMD = wash reg push --insecure $(REG_URL)
 
+# friendly name for the actor
+ACTOR_NAME = "{{project-name}}"
+# optional call alias for actor
+# ACTOR_ALIAS=nickname
+
 include ./actor.mk
 

--- a/actor/hello/Makefile
+++ b/actor/hello/Makefile
@@ -10,5 +10,10 @@ REG_URL  = localhost:5000/v2/$(PROJECT):$(VERSION)
 # command to upload to registry (without last wasm parameter)
 PUSH_REG_CMD = wash reg push --insecure $(REG_URL)
 
+# friendly name for the actor
+ACTOR_NAME = "{{project-name}}"
+# optional call alias for actor
+# ACTOR_ALIAS=nickname
+
 include ./actor.mk
 


### PR DESCRIPTION

fixes [wash 170](https://github.com/wasmCloud/wash/issues/170)
adds support for call alias
 (define ACTOR_ALIAS in Makefile)
adds support for actor name
 (define ACTOR_NAME in Makefile), defaults to PROJECT if undefined

Signed-off-by: stevelr <steve@cosmonic.com>