### PR TITLE
replace `echo -n` with `printf`

### DIFF
--- a/provider/factorial/provider.mk
+++ b/provider/factorial/provider.mk
@@ -110,7 +110,7 @@ par-full: $(dest_par) $(bin_targets)
 		if [ $$target = "x86_64-pc-windows-gnu" ]; then \
 			target_dest=$$target_dest.exe;  \
 		fi; \
-	    par_arch=`echo -n $$target | sed -E 's/([^-]+)-([^-]+)-([^-]+)(-gnu.*)?/\1-\3/' | sed 's/darwin/macos/'`; \
+	    par_arch=`printf $$target | sed -E 's/([^-]+)-([^-]+)-([^-]+)(-gnu.*)?/\1-\3/' | sed 's/darwin/macos/'`; \
 		echo building $$par_arch; \
 		if [ $$target_dest != $(cross_target0) ] && [ -f $$target_dest ]; then \
 		    $(WASH) par insert --arch $$par_arch --binary $$target_dest $(dest_par); \
@@ -131,7 +131,7 @@ target/debug/$(bin_name): $(RUST_DEPS)
 
 # cross-compile target, remove intermediate build artifacts before build
 target/%/release/$(bin_name): $(RUST_DEPS)
-	tname=`echo -n $@ | sed -E 's_target/([^/]+)/release.*$$_\1_'` &&\
+	tname=`printf $@ | sed -E 's_target/([^/]+)/release.*$$_\1_'` &&\
 	rm -rf target/release/build &&\
 	cross build --release --target $$tname
 

--- a/test/generate-all-templates.sh
+++ b/test/generate-all-templates.sh
@@ -3,41 +3,39 @@
 # generate all templates and build them
 
 TEST_DIR=$(mktemp -d)
-OUTPUT=${PWD}/new-project.out
-echo Generating projects in $TEST_DIR
+echo Generating projects in "$TEST_DIR"
 
 src_dir=$PWD/..
 
-function run_template () {
-    local proj_type=$1
-    local proj_name=$2
-    local template_path=$3
+function run_template() {
+	local proj_type=$1
+	local proj_name=$2
+	local template_path=$3
 
-    (cd $TEST_DIR &&\
-    wash new $proj_type --silent --path $template_path $proj_name &&\
-    cd $proj_name &&\
-    make &&\
-    make test)
+	(cd "$TEST_DIR" &&
+		wash new "$proj_type" --silent --path "$template_path" "$proj_name" &&
+		cd "$proj_name" &&
+		make &&
+		make test)
 }
 
-function test_template () {
-    local proj_type=$1
-    local proj_name=$2
-    local template_path=$3
+function test_template() {
+	local proj_type=$1
+	local proj_name=$2
+	local template_path=$3
 
-    local log="log_$(date '+%Y%m%d_%H%M%S')_$proj_type"
-    echo -n "$proj_type $proj_name ..."
-    run_template $proj_type $proj_name $template_path >$log 2>&1
-    if [ $? -eq 0 ]; then
-        echo "Passed"
-    else
-        echo "Failed. Log in $log"
-    fi
+	local log
+	log="log_$(date '+%Y%m%d_%H%M%S')_$proj_type"
+	printf "%s %s ..." "$proj_type" "$proj_name"
+	if run_template "$proj_type" "$proj_name" "$template_path" >"$log" 2>&1; then
+		echo "Passed"
+	else
+		echo "Failed. Log in $log"
+	fi
 }
 
-test_template actor     my-hello $src_dir/actor/hello
-test_template actor     my-echo  $src_dir/actor/echo
-test_template interface my-ifa   $src_dir/interface/converter-actor
-test_template interface my-iff   $src_dir/interface/factorial
-test_template provider  my-pr1   $src_dir/provider/factorial
-
+test_template actor my-hello "$src_dir/actor/hello"
+test_template actor my-echo "$src_dir/actor/echo"
+test_template interface my-ifa "$src_dir/interface/converter-actor"
+test_template interface my-iff "$src_dir/interface/factorial"
+test_template provider my-pr1 "$src_dir/provider/factorial"


### PR DESCRIPTION
The main purpose of this PR is to replace `echo -n` (the `-n` switch doesn't exist on darwin) with the POSIX `printf` command. Unfortunately I didn't have the heart to stop my IDE executing `shfmt` and I also couldn't quite resist paying attention to the `shellcheck` warnings in `generate-all-templates.sh`. :-)

However, when testing it with `wash 0.6.6`, the tests fail with `Error: prefix not found`. This appears to be an existing problem — i.e. not introduced by this PR.