### PR TITLE
fix: timeout and rpc-timeout changed to ms

### DIFF
--- a/actor/echo/actor.mk
+++ b/actor/echo/actor.mk
@@ -82,7 +82,7 @@ push: $(DIST_WASM)
 
 # tell host to start an instance of the actor
 start:
-	$(WASH) ctl start actor $(REG_URL) --timeout 3
+	$(WASH) ctl start actor $(REG_URL) --timeout-ms 3000
 
 # NOT WORKING - live actor updates not working yet
 # update it (should update revision before doing this)
@@ -91,17 +91,17 @@ start:
 #	$(WASH) ctl update actor  \
 #        $(shell $(WASH) ctl get hosts -o json | jq -r ".hosts[0].id") \
 #	    $(shell make --silent actor_id) \
-#	    $(REG_URL) --timeout 3
+#	    $(REG_URL) --timeout-ms 3000
 
 inventory:
 	$(WASH) ctl get inventory $(shell $(WASH) ctl get hosts -o json | jq -r ".hosts[0].id")
 
 ifneq ($(wildcard test-options.json),)
 # if this is a test actor, run its start method
-# project makefile can set RPC_TEST_TIMEOUT to override default
-RPC_TEST_TIMEOUT ?= 2
+# project makefile can set RPC_TEST_TIMEOUT_MS to override default
+RPC_TEST_TIMEOUT_MS ?= 2000
 test::
-	$(WASH) call --test --data test-options.json --rpc-timeout $(TEST_TIMEOUT) \
+	$(WASH) call --test --data test-options.json --rpc-timeout-ms $(RPC_TEST_TIMEOUT_MS) \
 	    $(shell make --silent actor_id) \
 	    Start
 endif

--- a/actor/hello/actor.mk
+++ b/actor/hello/actor.mk
@@ -82,7 +82,7 @@ push: $(DIST_WASM)
 
 # tell host to start an instance of the actor
 start:
-	$(WASH) ctl start actor $(REG_URL) --timeout 3
+	$(WASH) ctl start actor $(REG_URL) --timeout-ms 3000
 
 # NOT WORKING - live actor updates not working yet
 # update it (should update revision before doing this)
@@ -91,17 +91,17 @@ start:
 #	$(WASH) ctl update actor  \
 #        $(shell $(WASH) ctl get hosts -o json | jq -r ".hosts[0].id") \
 #	    $(shell make --silent actor_id) \
-#	    $(REG_URL) --timeout 3
+#	    $(REG_URL) --timeout-ms 3000
 
 inventory:
 	$(WASH) ctl get inventory $(shell $(WASH) ctl get hosts -o json | jq -r ".hosts[0].id")
 
 ifneq ($(wildcard test-options.json),)
 # if this is a test actor, run its start method
-# project makefile can set RPC_TEST_TIMEOUT to override default
-RPC_TEST_TIMEOUT ?= 2
+# project makefile can set RPC_TEST_TIMEOUT_MS to override default
+RPC_TEST_TIMEOUT_MS ?= 2000
 test::
-	$(WASH) call --test --data test-options.json --rpc-timeout $(TEST_TIMEOUT) \
+	$(WASH) call --test --data test-options.json --rpc-timeout-ms $(RPC_TEST_TIMEOUT_MS) \
 	    $(shell make --silent actor_id) \
 	    Start
 endif

--- a/provider/factorial/provider.mk
+++ b/provider/factorial/provider.mk
@@ -154,7 +154,7 @@ start:
 	$(WASH) ctl start provider $(oci_url) \
 		--host-id $(shell $(WASH) ctl get hosts -o json | jq -r ".hosts[0].id") \
 		--link-name $(link_name) \
-		--timeout 4
+		--timeout-ms 4000
 
 # inspect claims on par file
 inspect: $(dest_par)


### PR DESCRIPTION
Related to a naming convention change a week ago:
wasmCloud/wash#198