### PR TITLE
Project templates for providers

### DIFF
--- a/actor/echo-tinygo/.github/workflows/release.yml
+++ b/actor/echo-tinygo/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
           files: build/*_s.wasm
           token: ${{ env.WASMCLOUD_PAT }}
           body_path: release.txt
-          prerelease: true
+          prerelease: false
           draft: false
 
   artifact_release:

--- a/actor/echo-tinygo/README.md
+++ b/actor/echo-tinygo/README.md
@@ -37,6 +37,6 @@ It should print the response "hello" on your console.
 If you store your source code on Github, we've gone ahead and included two actions: `build.yml` and `release.yml` under `.github/workflows`. The build action will automatically build, lint, and check formatting for your actor. The release action will automatically release a new version of your actor whenever code is pushed to `main`, or when you push a tag with the form `vX.Y.Z`. 
 
 These actions require 3 secrets
-1. `WASH_ISSUER_KEY`, which can be generated with `wash keys gen issuer`, then look for the 56 character `Seed` value
-1. `WASH_SUBJECT_KEY`, which can be generated with `wash keys gen module`, then look for the 56 character `Seed` value
+1. `WASH_ISSUER_KEY`, which can be generated with `wash keys gen issuer`, then look for the 58 character `Seed` value
+1. `WASH_SUBJECT_KEY`, which can be generated with `wash keys gen module`, then look for the 58 character `Seed` value
 1. `WASMCLOUD_PAT`, which can be created by following the [Github PAT instructions](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) and ensuring the `write:packages` permission is enabled

--- a/actor/echo-tinygo/README.md
+++ b/actor/echo-tinygo/README.md
@@ -33,3 +33,10 @@ curl -v localhost:8085/abc
 ```
 It should print the response "hello" on your console.
 
+### Using the included Github Actions
+If you store your source code on Github, we've gone ahead and included two actions: `build.yml` and `release.yml` under `.github/workflows`. The build action will automatically build, lint, and check formatting for your actor. The release action will automatically release a new version of your actor whenever code is pushed to `main`, or when you push a tag with the form `vX.Y.Z`. 
+
+These actions require 3 secrets
+1. `WASH_ISSUER_KEY`, which can be generated with `wash keys gen issuer`, then look for the 56 character `Seed` value
+1. `WASH_SUBJECT_KEY`, which can be generated with `wash keys gen module`, then look for the 56 character `Seed` value
+1. `WASMCLOUD_PAT`, which can be created by following the [Github PAT instructions](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) and ensuring the `write:packages` permission is enabled

--- a/actor/echo/.github/workflows/release.yml
+++ b/actor/echo/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
           files: build/*.wasm
           token: ${{ env.WASMCLOUD_PAT }}
           body_path: release.txt
-          prerelease: true
+          prerelease: false
           draft: false
 
   artifact_release:

--- a/actor/echo/Cargo.toml
+++ b/actor/echo/Cargo.toml
@@ -11,8 +11,8 @@ name = "{{to_snake_case project-name}}"
 [dependencies]
 futures = "0.3"
 serde_json ="1.0"
-wasmbus-rpc = "0.8.2"
-wasmcloud-interface-httpserver = "0.5"
+wasmbus-rpc = "0.9"
+wasmcloud-interface-httpserver = "0.6"
 
 [profile.release]
 # Optimize for small code size

--- a/actor/echo/README.md
+++ b/actor/echo/README.md
@@ -7,7 +7,7 @@ For each http request, the actor returns a json-formatted
 string containing fields from the request.
 
 ### Using the included Github Actions
-If you store your source code on Github, we've gone ahead and included two actions: `build.yml` and `release.yml` under `.github/workflows`. The build action will automatically build, lint, and check formatting for your actor. The release action will automatically release a new version of your actor whenever code is pushed to `main`, or when you push a tag with the form `hello-vX.Y.Z`. 
+If you store your source code on Github, we've gone ahead and included two actions: `build.yml` and `release.yml` under `.github/workflows`. The build action will automatically build, lint, and check formatting for your actor. The release action will automatically release a new version of your actor whenever code is pushed to `main`, or when you push a tag with the form `vX.Y.Z`. 
 
 These actions require 3 secrets
 1. `WASH_ISSUER_KEY`, which can be generated with `wash keys gen issuer`, then look for the 56 character `Seed` value

--- a/actor/echo/README.md
+++ b/actor/echo/README.md
@@ -10,6 +10,6 @@ string containing fields from the request.
 If you store your source code on Github, we've gone ahead and included two actions: `build.yml` and `release.yml` under `.github/workflows`. The build action will automatically build, lint, and check formatting for your actor. The release action will automatically release a new version of your actor whenever code is pushed to `main`, or when you push a tag with the form `vX.Y.Z`. 
 
 These actions require 3 secrets
-1. `WASH_ISSUER_KEY`, which can be generated with `wash keys gen issuer`, then look for the 56 character `Seed` value
-1. `WASH_SUBJECT_KEY`, which can be generated with `wash keys gen module`, then look for the 56 character `Seed` value
+1. `WASH_ISSUER_KEY`, which can be generated with `wash keys gen issuer`, then look for the 58 character `Seed` value
+1. `WASH_SUBJECT_KEY`, which can be generated with `wash keys gen module`, then look for the 58 character `Seed` value
 1. `WASMCLOUD_PAT`, which can be created by following the [Github PAT instructions](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) and ensuring the `write:packages` permission is enabled

--- a/actor/hello/.github/workflows/release.yml
+++ b/actor/hello/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
           files: build/*.wasm
           token: ${{ env.WASMCLOUD_PAT }}
           body_path: release.txt
-          prerelease: true
+          prerelease: false
           draft: false
 
   artifact_release:

--- a/actor/hello/Cargo.toml
+++ b/actor/hello/Cargo.toml
@@ -11,8 +11,8 @@ name = "{{to_snake_case project-name}}"
 [dependencies]
 futures = "0.3"
 form_urlencoded = "1.0"
-wasmbus-rpc = "0.8.2"
-wasmcloud-interface-httpserver = "0.5"
+wasmbus-rpc = "0.9"
+wasmcloud-interface-httpserver = "0.6"
 
 [profile.release]
 # Optimize for small code size

--- a/actor/hello/README.md
+++ b/actor/hello/README.md
@@ -54,7 +54,7 @@ curl "localhost:8000/?name=Alice"
 visit the url "http://localhost:8000" or "http://localhost:8000/?name=Alice"
 
 ### Using the included Github Actions
-If you store your source code on Github, we've gone ahead and included two actions: `build.yml` and `release.yml` under `.github/workflows`. The build action will automatically build, lint, and check formatting for your actor. The release action will automatically release a new version of your actor whenever code is pushed to `main`, or when you push a tag with the form `hello-vX.Y.Z`. 
+If you store your source code on Github, we've gone ahead and included two actions: `build.yml` and `release.yml` under `.github/workflows`. The build action will automatically build, lint, and check formatting for your actor. The release action will automatically release a new version of your actor whenever code is pushed to `main`, or when you push a tag with the form `vX.Y.Z`. 
 
 These actions require 3 secrets
 1. `WASH_ISSUER_KEY`, which can be generated with `wash keys gen issuer`, then look for the 56 character `Seed` value

--- a/actor/hello/README.md
+++ b/actor/hello/README.md
@@ -57,6 +57,6 @@ visit the url "http://localhost:8000" or "http://localhost:8000/?name=Alice"
 If you store your source code on Github, we've gone ahead and included two actions: `build.yml` and `release.yml` under `.github/workflows`. The build action will automatically build, lint, and check formatting for your actor. The release action will automatically release a new version of your actor whenever code is pushed to `main`, or when you push a tag with the form `vX.Y.Z`. 
 
 These actions require 3 secrets
-1. `WASH_ISSUER_KEY`, which can be generated with `wash keys gen issuer`, then look for the 56 character `Seed` value
-1. `WASH_SUBJECT_KEY`, which can be generated with `wash keys gen module`, then look for the 56 character `Seed` value
+1. `WASH_ISSUER_KEY`, which can be generated with `wash keys gen issuer`, then look for the 58 character `Seed` value
+1. `WASH_SUBJECT_KEY`, which can be generated with `wash keys gen module`, then look for the 58 character `Seed` value
 1. `WASMCLOUD_PAT`, which can be created by following the [Github PAT instructions](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) and ensuring the `write:packages` permission is enabled

--- a/interface/converter-actor/rust/Cargo.toml
+++ b/interface/converter-actor/rust/Cargo.toml
@@ -14,14 +14,14 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 async-trait = "0.1"
-serde = { version = "1.0" , features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11.5"
-wasmbus-rpc = "0.8.2"
+wasmbus-rpc = "0.9"
 
 [dev-dependencies]
 base64 = "0.13"
 
 # build-dependencies needed for build.rs
 [build-dependencies]
-weld-codegen = "0.4.2"
+weld-codegen = "0.4.6"
 

--- a/interface/factorial/rust/Cargo.toml
+++ b/interface/factorial/rust/Cargo.toml
@@ -14,14 +14,14 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 async-trait = "0.1"
-serde = { version = "1.0" , features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11.5"
-wasmbus-rpc = "0.8.2"
+wasmbus-rpc = "0.9"
 
 [dev-dependencies]
 base64 = "0.13"
 
 # build-dependencies needed for build.rs
 [build-dependencies]
-weld-codegen = "0.4.2"
+weld-codegen = "0.4.6"
 

--- a/provider/factorial/.github/workflows/build.yml
+++ b/provider/factorial/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Build and Test
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "Cargo.*"
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check formatting
+        run: cargo fmt -- --check
+        shell: bash
+      - name: Check lints with clippy
+        run: |
+          rustup component add clippy
+          cargo clippy
+      - name: Build provider
+        run: cargo build
+      # If your integration tests depend on NATS or Redis you can enable them here
+      - uses: wasmcloud/common-actions/run-nats@main
+      # - uses: wasmcloud/common-actions/run-redis@main
+      - name: Test provider
+        run: cargo test -- --nocapture

--- a/provider/factorial/.github/workflows/release.yml
+++ b/provider/factorial/.github/workflows/release.yml
@@ -1,0 +1,133 @@
+name: Release
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "**"
+      - "src/**"
+      - "Cargo.*"
+    tags:
+      - "v*"
+env:
+  # For the release action, you'll have to set the following variables
+  WASH_ISSUER_KEY: ${{ secrets.WASH_ISSUER_KEY }}
+  WASH_SUBJECT_KEY: ${{ secrets.WASH_SUBJECT_KEY }}
+  WASMCLOUD_PAT: ${{ secrets.WASMCLOUD_PAT }}
+jobs:
+  # Using a matrix, build for 6 supported targets for wasmCloud providers
+  build_provider_targets:
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - x86_64-apple-darwin
+          - aarch64-unknown-linux-gnu
+          - aarch64-apple-darwin
+          - armv7-unknown-linux-gnueabihf
+          - x86_64-pc-windows-gnu
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: wasmcloud/common-actions/install-cross@main
+      - name: Determine artifact name
+        run: |
+          echo "artifact-name=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].targets[0].name')" >> $GITHUB_ENV
+      - name: Build native executable
+        run: |
+          cross build --release --target ${{ matrix.target }}
+      - name: Upload executable to GH Actions
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.target }}
+          if-no-files-found: error
+          path: |
+            target/${{ matrix.target }}/release/${{ env.artifact-name }}
+            target/${{ matrix.target }}/release/${{ env.artifact-name }}.exe
+
+  assemble_provider_archive:
+    needs: [build_provider_targets]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: wasmcloud/common-actions/install-wash@main
+      # Downloads all provider artifacts
+      - uses: actions/download-artifact@v3
+      - name: Determine artifact name
+        run: |
+          echo "artifact-name=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].targets[0].name')" >> $GITHUB_ENV
+      - name: Create provider archive
+        run: |
+          mkdir -p target/release
+          mv x86_64-unknown-linux-gnu/${{ env.artifact-name }} target/release/
+          make par
+      - name: Fill provider archive with binaries
+        run: |
+          wash par insert --arch x86_64-macos   --binary x86_64-apple-darwin/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch aarch64-linux  --binary aarch64-unknown-linux-gnu/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch aarch64-macos  --binary aarch64-apple-darwin/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch armv7-linux    --binary armv7-unknown-linux-gnueabihf/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch x86_64-windows --binary x86_64-pc-windows-gnu/${{ env.artifact-name }}.exe build/${{ env.artifact-name }}.par.gz
+      - name: Upload provider archive to GH Actions
+        uses: actions/upload-artifact@v2
+        with:
+          name: provider-archive
+          path: build/${{ env.artifact-name }}.par.gz
+
+  github_release:
+    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    needs: [assemble_provider_archive]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download provider archive
+        uses: actions/download-artifact@v3
+        with:
+          name: provider-archive
+          path: build
+      - name: Create release text
+        run: |
+          export oci_version=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
+          export claims=$(wash par inspect build/*.par.gz)
+          echo "Your provider can be accessed at \`ghcr.io/${{ github.REPOSITORY }}:$oci_version\`" >> release.txt
+          echo "Claims information:" >> release.txt
+          echo "\`\`\`" >> release.txt
+          echo "$claims" >> release.txt
+          echo "\`\`\`" >> release.txt
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: build/*.par.gz
+          token: ${{ env.WASMCLOUD_PAT }}
+          body_path: release.txt
+          prerelease: false
+          draft: false
+
+  artifact_release:
+    needs: [assemble_provider_archive]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: wasmcloud/common-actions/install-wash@main
+      - name: Download provider archive
+        uses: actions/download-artifact@v3
+        with:
+          name: provider-archive
+          path: build
+
+      - name: Determine provider name
+        run: |
+          echo "provider-name=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name')" >> $GITHUB_ENV
+      - name: Determine provider version
+        if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+        run: |
+          echo "provider-version=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')" >> $GITHUB_ENV
+      - name: Determine provider version (main)
+        if: ${{ !startswith(github.ref, 'refs/tags/') }}
+        run: |
+          echo "provider-version=latest" >> $GITHUB_ENV
+      - name: Push provider archive to GHCR
+        env:
+          WASH_REG_USER: ${{ github.repository_owner }}
+          WASH_REG_PASSWORD: ${{ secrets.WASMCLOUD_PAT }}
+        run: |
+          wash reg push ghcr.io/${{ github.REPOSITORY }}:${{ env.provider-version }} build/${{ env.provider-name }}.par.gz -a org.opencontainers.image.source=https://github.com/${{ github.REPOSITORY }} --allow-latest

--- a/provider/factorial/.github/workflows/release.yml
+++ b/provider/factorial/.github/workflows/release.yml
@@ -79,6 +79,8 @@ jobs:
     needs: [assemble_provider_archive]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
+      - uses: wasmcloud/common-actions/install-wash@main
       - name: Download provider archive
         uses: actions/download-artifact@v3
         with:

--- a/provider/factorial/Cargo.toml
+++ b/provider/factorial/Cargo.toml
@@ -6,13 +6,12 @@ resolver = "2"
 
 [dependencies]
 async-trait = "0.1"
-log = "0.4"
-wasmcloud-interface-factorial = "0.4"
-wasmbus-rpc = "0.8.2"
+wasmcloud-interface-factorial = "0.5.0"
+wasmbus-rpc = "0.9"
 
 # test dependencies
 [dev-dependencies]
-wasmcloud-test-util = "0.3.1"
+wasmcloud-test-util = "0.4.0"
 tokio = { version = "1.0", features = [ "full" ] }
 
 [[bin]]

--- a/provider/factorial/Cross.toml
+++ b/provider/factorial/Cross.toml
@@ -1,0 +1,14 @@
+[target.armv7-unknown-linux-gnueabihf]
+image = "wasmcloud/cross:armv7-unknown-linux-gnueabihf"
+
+[target.aarch64-unknown-linux-gnu]
+image = "wasmcloud/cross:aarch64-unknown-linux-gnu"
+
+[target.x86_64-apple-darwin]
+image = "wasmcloud/cross:x86_64-apple-darwin"
+
+[target.aarch64-apple-darwin]
+image = "wasmcloud/cross:aarch64-apple-darwin"
+
+[target.x86_64-unknown-linux-gnu]
+image = "wasmcloud/cross:x86_64-unknown-linux-gnu"

--- a/provider/factorial/README.md
+++ b/provider/factorial/README.md
@@ -6,3 +6,10 @@ and calculates "n factorial" for the provided whole number n.
 
 Build with 'make'. Test with 'make test'.
 
+### Using the included Github Actions
+If you store your source code on Github, we've gone ahead and included two actions: `build.yml` and `release.yml` under `.github/workflows`. The build action will automatically build, lint, and check formatting for your actor. The release action will automatically release a new version of your actor whenever code is pushed to `main`, or when you push a tag with the form `vX.Y.Z`. 
+
+These actions require 3 secrets
+1. `WASH_ISSUER_KEY`, which can be generated with `wash keys gen issuer`, then look for the 58 character `Seed` value
+1. `WASH_SUBJECT_KEY`, which can be generated with `wash keys gen module`, then look for the 58 character `Seed` value
+1. `WASMCLOUD_PAT`, which can be created by following the [Github PAT instructions](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) and ensuring the `write:packages` permission is enabled

--- a/provider/factorial/project-generate.toml
+++ b/provider/factorial/project-generate.toml
@@ -3,9 +3,13 @@ rename = [
   { from="tests/factorial_test.rs", to="tests/{{to_snake_case project-name}}_test.rs" },
 ]
 
+raw = [
+  ".github/workflows/build.yml",
+  ".github/workflows/release.yml",
+]
+
 [[placeholders]]
 name = "vendor_name"
 type = "string"
 prompt = "Vendor name?"
 default = "Acme"
-

--- a/provider/factorial/provider_test_config.toml
+++ b/provider/factorial/provider_test_config.toml
@@ -2,7 +2,7 @@
 
 # name of compiled binary (usually project name unless overridden in [[bin]]
 # Required
-bin_path = "target/release/{{ to_snake_case project-name }}"
+bin_path = "target/debug/{{ to_snake_case project-name }}"
 
 # set RUST_LOG environment variable (default "info")
 rust_log = "debug"

--- a/provider/factorial/src/main.rs
+++ b/provider/factorial/src/main.rs
@@ -1,7 +1,6 @@
 //! {{ project-name }} capability provider
 //!
 //!
-use log::debug;
 use wasmbus_rpc::provider::prelude::*;
 use wasmcloud_interface_factorial::{Factorial, FactorialReceiver};
 
@@ -10,7 +9,7 @@ use wasmcloud_interface_factorial::{Factorial, FactorialReceiver};
 // and returns only when it receives a shutdown message
 //
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    provider_main({{ to_pascal_case project-name }}Provider::default())?;
+    provider_main({{ to_pascal_case project-name }}Provider::default(), Some("{{ to_pascal_case project-name }}".to_string()))?;
 
     eprintln!("{{ project-name }} provider exiting");
     Ok(())
@@ -30,7 +29,7 @@ impl ProviderHandler for {{ to_pascal_case project-name }}Provider {}
 impl Factorial for {{ to_pascal_case project-name }}Provider {
     /// accepts a number and calculates its factorial
     async fn calculate(&self, _ctx: &Context, req: &u32) -> RpcResult<u64> {
-        debug!("processing request calculat({})", *req);
+        debug!("processing request calculate ({})", *req);
         Ok(n_factorial(*req))
     }
 }


### PR DESCRIPTION
This PR:
- Updates wasmbus-rpc crates to their 0.9 compatible versions
- Ensures all project readme's have instructions for the build/release pipelines
- Adds the build and release pipelines for a capability provider (instructions the exact same as actors)

You can see an example repository created with the build/release templates for factorial at https://github.com/brooksmtownsend/factorial

and a release at https://github.com/brooksmtownsend/factorial/releases/tag/v0.1.2