### PR TITLE
add echo-messaging actor template

### DIFF
--- a/actor/echo-messaging/.cargo/config.toml
+++ b/actor/echo-messaging/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "wasm32-unknown-unknown"

--- a/actor/echo-messaging/.cargo/config.toml
+++ b/actor/echo-messaging/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "wasm32-unknown-unknown"
+target = "wasm32-wasi"

--- a/actor/echo-messaging/.github/workflows/build.yml
+++ b/actor/echo-messaging/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: Build and test
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "Cargo.*"
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Add wasm32-unknown-unknown
+        run: rustup target add wasm32-unknown-unknown
+      - name: Check formatting
+        run: cargo fmt -- --check
+        shell: bash
+      - name: Build actor
+        run: cargo build
+      - name: Check lints with clippy
+        run: |
+          rustup component add clippy
+          cargo clippy
+      # Once you've written unit tests for your actor, you can uncomment
+      # the two lines below to automatically run tests
+      # - name: Test actor
+      #   run: cargo test --target x86_64-unknown-linux-gnu -- --nocapture

--- a/actor/echo-messaging/.github/workflows/release.yml
+++ b/actor/echo-messaging/.github/workflows/release.yml
@@ -1,0 +1,97 @@
+name: Release to GHCR
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "**"
+      - "src/**"
+      - "Cargo.*"
+    tags:
+      - "v*"
+env:
+  # For the release action, you'll have to set the following variables
+  WASH_ISSUER_KEY: ${{ secrets.WASH_ISSUER_KEY }}
+  WASH_SUBJECT_KEY: ${{ secrets.WASH_SUBJECT_KEY }}
+  WASMCLOUD_PAT: ${{ secrets.WASMCLOUD_PAT }}
+jobs:
+  build_signed_actor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: wasmcloud/common-actions/install-wash@main
+      - name: Add wasm32-unknown-unknown
+        run: rustup target add wasm32-unknown-unknown
+      # Once you've written unit tests for your actor, you can uncomment
+      # the two lines below to automatically run tests
+      # - name: Test actor
+      #   run: cargo test --target x86_64-unknown-linux-gnu -- --nocapture
+      - name: Build and sign wasmCloud actor
+        env:
+          WASH_ISSUER_KEY: ${{ env.WASH_ISSUER_KEY }}
+          WASH_SUBJECT_KEY: ${{ env.WASH_SUBJECT_KEY }}
+        run: make
+      - name: Upload signed actor to GH Actions
+        uses: actions/upload-artifact@v2
+        with:
+          name: wasmcloud-actor
+          path: build/*.wasm
+
+  github_release:
+    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    needs: build_signed_actor
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: wasmcloud/common-actions/install-wash@main
+      - name: Download signed actor
+        uses: actions/download-artifact@v2
+        with:
+          name: wasmcloud-actor
+          path: build
+      - name: Create release text
+        run: |
+          export oci_version=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
+          export claims=$(wash claims inspect build/*.wasm)
+          echo "Your actor can be accessed at \`ghcr.io/${{ github.REPOSITORY }}:$oci_version\`" >> release.txt
+          echo "Claims information:" >> release.txt
+          echo "\`\`\`" >> release.txt
+          echo "$claims" >> release.txt
+          echo "\`\`\`" >> release.txt
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: build/*.wasm
+          token: ${{ env.WASMCLOUD_PAT }}
+          body_path: release.txt
+          prerelease: false
+          draft: false
+
+  artifact_release:
+    needs: build_signed_actor
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: wasmcloud/common-actions/install-wash@main
+      - name: Download signed actor
+        uses: actions/download-artifact@v2
+        with:
+          name: wasmcloud-actor
+          path: build
+      - name: Determine actor name
+        run: |
+          echo "actor-name=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name')" >> $GITHUB_ENV
+      - name: Determine actor version
+        if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+        run: |
+          echo "actor-version=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')" >> $GITHUB_ENV
+      - name: Determine actor version (main)
+        if: ${{ !startswith(github.ref, 'refs/tags/') }}
+        run: |
+          echo "actor-version=latest" >> $GITHUB_ENV
+      - name: Push actor to GHCR
+        env:
+          WASH_REG_USER: ${{ github.repository_owner }}
+          WASH_REG_PASSWORD: ${{ secrets.WASMCLOUD_PAT }}
+        run: |
+          wash reg push ghcr.io/${{ github.REPOSITORY }}:${{ env.actor-version }} build/${{ env.actor-name }}_s.wasm -a org.opencontainers.image.source=https://github.com/${{ github.REPOSITORY }} --allow-latest

--- a/actor/echo-messaging/.gitignore
+++ b/actor/echo-messaging/.gitignore
@@ -1,0 +1,40 @@
+# This file lists build byproducts, 
+# IDE-specific files (unless shared by your team)
+
+## Build
+/build
+/dist/
+/target
+**target
+
+## File system
+.DS_Store
+desktop.ini
+
+## Editor
+*.swp
+*.swo
+Session.vim
+.cproject
+.idea
+*.iml
+.vscode
+.project
+.favorites.json
+.settings/
+
+## Temporary files
+*~
+\#*
+\#*\#
+.#*
+
+## Python
+__pycache__/
+*.py[cod]
+*$py.class
+
+## Node
+**node_modules
+**package-lock.json
+

--- a/actor/echo-messaging/Cargo.toml
+++ b/actor/echo-messaging/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "echo-messaging"
+version = "0.1.0"
+authors = [ "" ]
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+name = "echo_messaging"
+
+[dependencies]
+futures = "0.3"
+serde_json = "1.0"
+wasmbus-rpc = "0.11"
+wasmcloud-interface-messaging = "0.8"
+
+[profile.release]
+# Optimize for small code size
+lto = true
+opt-level = "s"

--- a/actor/echo-messaging/Cargo.toml
+++ b/actor/echo-messaging/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "echo-messaging"
+name = "{{project-name}}"
 version = "0.1.0"
 authors = [ "" ]
 edition = "2021"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
-name = "echo_messaging"
+name = "{{to_snake_case project-name}}"
 
 [dependencies]
 futures = "0.3"
@@ -18,3 +18,4 @@ wasmcloud-interface-messaging = "0.8"
 # Optimize for small code size
 lto = true
 opt-level = "s"
+strip = true

--- a/actor/echo-messaging/Makefile
+++ b/actor/echo-messaging/Makefile
@@ -1,0 +1,21 @@
+# Makefile for {{project-name}}
+
+PROJECT  = {{to_snake_case project-name}}
+VERSION  = $(shell cargo metadata --no-deps --format-version 1 | jq -r '.packages[] .version' | head -1)
+REVISION = 0
+# list of all contract claims for actor signing (space-separated)
+CLAIMS   = wasmcloud:httpserver
+# registry url for our actor
+REG_URL  = localhost:5000/v2/$(PROJECT):$(VERSION)
+# command to upload to registry (without last wasm parameter)
+PUSH_REG_CMD = wash reg push --insecure $(REG_URL)
+
+# friendly name for the actor
+ACTOR_NAME = "{{project-name}}"
+# optional call alias for actor
+# ACTOR_ALIAS=nickname
+
+include ./actor.mk
+
+test::
+	cargo clippy --all-features --all-targets

--- a/actor/echo-messaging/README.md
+++ b/actor/echo-messaging/README.md
@@ -1,0 +1,15 @@
+# {{project-name}}
+
+This actor echoes messages received in an HttpRequest.
+It is linked to the http server provider wasmcloud:httpserver.
+
+For each http request, the actor returns a json-formatted
+string containing fields from the request.
+
+### Using the included Github Actions
+If you store your source code on Github, we've gone ahead and included two actions: `build.yml` and `release.yml` under `.github/workflows`. The build action will automatically build, lint, and check formatting for your actor. The release action will automatically release a new version of your actor whenever code is pushed to `main`, or when you push a tag with the form `vX.Y.Z`. 
+
+These actions require 3 secrets
+1. `WASH_ISSUER_KEY`, which can be generated with `wash keys gen issuer`, then look for the 58 character `Seed` value
+1. `WASH_SUBJECT_KEY`, which can be generated with `wash keys gen module`, then look for the 58 character `Seed` value
+1. `WASMCLOUD_PAT`, which can be created by following the [Github PAT instructions](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) and ensuring the `write:packages` permission is enabled

--- a/actor/echo-messaging/README.md
+++ b/actor/echo-messaging/README.md
@@ -1,10 +1,10 @@
 # {{project-name}}
 
-This actor echoes messages received in an HttpRequest.
-It is linked to the http server provider wasmcloud:httpserver.
+This actor echoes messages received in a `SubMessage`. It is linked to the NATS
+messaging provider with the contract `wasmcloud:messaging`.
 
-For each http request, the actor returns a json-formatted
-string containing fields from the request.
+For each incoming NATS message, the actor echoes the bytes back out to the
+`reply_to` topic on the message
 
 ### Using the included Github Actions
 If you store your source code on Github, we've gone ahead and included two actions: `build.yml` and `release.yml` under `.github/workflows`. The build action will automatically build, lint, and check formatting for your actor. The release action will automatically release a new version of your actor whenever code is pushed to `main`, or when you push a tag with the form `vX.Y.Z`. 

--- a/actor/echo-messaging/actor.mk
+++ b/actor/echo-messaging/actor.mk
@@ -1,0 +1,138 @@
+# common makefile rules for building actors
+#
+# Before including this, your project Makefile should define the following:
+#
+# Required
+# -----------
+# PROJECT      - Short name for the project, must be valid filename chars, no spaces
+# CLAIMS       - Space-separated list of capability contracts to use for signing
+#                These should match the capability providers the actor needs to use.
+#                For example: 
+#                    wasmcloud:httpserver wasmcloud:builtin:logging
+# VERSION      - The actor version number, usually semver format, X.Y.Z
+# REVISION     - A number that should be incremented with every build,
+#                whether or not VERSION has changed
+# REG_URL      - Registry url, e.g. 'localhost:5000' or 'wasmcloud.azurecr.io'
+# PUSH_REG_CMD - Command to push to registry, for example:
+#                    wash reg push --insecure $(REG_URL)
+#
+# 
+# Optional
+# -----------
+# KEYDIR    - path to private key folder
+# CARGO     - cargo binary (name or path), defaults to cargo
+# WASH      - wash binary (name or path), defaults to wash
+# DIST_WASM - the final file after building and signing
+# TARGET_DIR - location of cargo build target folder if not in current dir
+#              (if it's in a workspace, it may be elsewhere)
+# WASM_TARGET - type of wasm file, defaults to wasm32-unknown-unknown
+#
+
+KEYDIR    ?= .keys
+CARGO     ?= cargo
+WASH      ?= wash
+# location of cargo output files
+TARGET_DIR ?= target
+# location of wasm file after build and signing
+DIST_WASM ?= build/$(PROJECT)_s.wasm
+WASM_TARGET ?= wasm32-unknown-unknown
+ACTOR_NAME  ?= $(PROJECT)
+UNSIGNED_WASM = $(TARGET_DIR)/$(WASM_TARGET)/release/$(PROJECT).wasm
+
+# verify all required variables are set
+check-var-defined = $(if $(strip $($1)),,$(error Required variable "$1" is not defined))
+
+$(call check-var-defined,PROJECT)
+$(call check-var-defined,CLAIMS)
+$(call check-var-defined,VERSION)
+$(call check-var-defined,REVISION)
+$(call check-var-defined,REG_URL)
+$(call check-var-defined,PUSH_REG_CMD)
+
+all:: $(DIST_WASM)
+
+# default target is signed wasm file
+# sign it
+$(DIST_WASM): $(UNSIGNED_WASM) Makefile
+	@mkdir -p $(dir $@)
+	$(WASH) claims sign $< \
+		$(foreach claim,$(CLAIMS), -c $(claim) ) \
+		--name $(ACTOR_NAME) --ver $(VERSION) --rev $(REVISION) \
+		$(if $(ACTOR_ALIAS),--call-alias $(ACTOR_ALIAS)) \
+		--destination $@
+
+# rules to print file name and path of build target
+target-path:
+	@echo $(DIST_WASM)
+target-path-abs:
+	@echo $(abspath $(DIST_WASM))
+target-file:
+	@echo $(notdir $(DIST_WASM))
+
+# the wasm should be rebuilt if any source files or dependencies change
+$(UNSIGNED_WASM): .FORCE
+	$(CARGO) build --release
+
+# push signed wasm file to registry
+push: $(DIST_WASM)
+	$(PUSH_REG_CMD) $(DIST_WASM)
+
+# tell host to start an instance of the actor
+start:
+	$(WASH) ctl start actor $(REG_URL) --timeout-ms 3000
+
+# NOT WORKING - live actor updates not working yet
+# update it (should update revision before doing this)
+#update:
+#	$(PUSH_REG_CMD) $(DIST_WASM)
+#	$(WASH) ctl update actor  \
+#        $(shell $(WASH) ctl get hosts -o json | jq -r ".hosts[0].id") \
+#	    $(shell make --silent actor_id) \
+#	    $(REG_URL) --timeout-ms 3000
+
+inventory:
+	$(WASH) ctl get inventory $(shell $(WASH) ctl get hosts -o json | jq -r ".hosts[0].id")
+
+ifneq ($(wildcard test-options.json),)
+# if this is a test actor, run its start method
+# project makefile can set RPC_TEST_TIMEOUT_MS to override default
+RPC_TEST_TIMEOUT_MS ?= 2000
+test::
+	$(WASH) call --test --data test-options.json --rpc-timeout-ms $(RPC_TEST_TIMEOUT_MS) \
+	    $(shell make --silent actor_id) \
+	    Start
+endif
+
+# generate release build
+release::
+	cargo build --release
+
+# standard rust commands
+check clippy doc:
+	$(CARGO) $@
+
+# remove 
+clean::
+	$(CARGO) clean
+	rm -rf build
+
+inspect claims: $(DIST_WASM)
+	$(WASH) claims inspect $(DIST_WASM)
+
+# need a signed wasm before we can print the id
+_actor_id: $(DIST_WASM)
+	@$(WASH) claims inspect $(DIST_WASM) -o json | jq -r .module
+
+actor_id:
+	@echo $(shell make --silent _actor_id 2>/dev/null | tail -1)
+
+ifeq ($(wildcard codegen.toml),codegen.toml)
+# if there are interfaces here, enable lint and validate rules
+lint validate::
+	$(WASH) $@
+else
+lint validate::
+
+endif
+
+.PHONY: actor_id check clean clippy doc release test update .FORCE

--- a/actor/echo-messaging/project-generate.toml
+++ b/actor/echo-messaging/project-generate.toml
@@ -1,0 +1,6 @@
+[template]
+
+raw = [
+  ".github/workflows/build.yml",
+  ".github/workflows/release.yml",
+]

--- a/actor/echo-messaging/src/lib.rs
+++ b/actor/echo-messaging/src/lib.rs
@@ -3,10 +3,10 @@ use wasmcloud_interface_messaging::*;
 
 #[derive(Debug, Default, Actor, HealthResponder)]
 #[services(Actor, MessageSubscriber)]
-struct EchoMessagingActor {}
+struct {{to_pascal_case project-name}}Actor {}
 
 #[async_trait]
-impl MessageSubscriber for EchoMessagingActor {
+impl MessageSubscriber for {{to_pascal_case project-name}}Actor {
     /// handle subscription response
     async fn handle_message(&self, ctx: &Context, msg: &SubMessage) -> RpcResult<()> {
         // if the sender wants a reply

--- a/actor/echo-messaging/src/lib.rs
+++ b/actor/echo-messaging/src/lib.rs
@@ -1,0 +1,27 @@
+use wasmbus_rpc::actor::prelude::*;
+use wasmcloud_interface_messaging::*;
+
+#[derive(Debug, Default, Actor, HealthResponder)]
+#[services(Actor, MessageSubscriber)]
+struct EchoMessagingActor {}
+
+#[async_trait]
+impl MessageSubscriber for EchoMessagingActor {
+    /// handle subscription response
+    async fn handle_message(&self, ctx: &Context, msg: &SubMessage) -> RpcResult<()> {
+        // if the sender wants a reply
+        if let Some(reply_to) = &msg.reply_to {
+            MessagingSender::new()
+                .publish(
+                    ctx,
+                    &PubMessage {
+                        body: msg.body.clone(),
+                        reply_to: None,
+                        subject: reply_to.to_owned(),
+                    },
+                )
+                .await?;
+        }
+        Ok(())
+    }
+}

--- a/actor/echo-messaging/wasmcloud.toml
+++ b/actor/echo-messaging/wasmcloud.toml
@@ -1,0 +1,7 @@
+name = "{{project-name}}"
+language = "rust"
+type = "actor"
+version = "0.1.0"
+
+[actor]
+claims = ["wasmcloud:messaging"]

--- a/actor/echo-messaging/wasmcloud.toml
+++ b/actor/echo-messaging/wasmcloud.toml
@@ -1,7 +1,8 @@
-name = "{{project-name}}"
+name = "{{to_snake_case project-name}}"
 language = "rust"
 type = "actor"
 version = "0.1.0"
 
 [actor]
 claims = ["wasmcloud:messaging"]
+wasm_target = "wasm32-wasi"


### PR DESCRIPTION
Tested on a branch of `wash` referencing my fork: `wash new actor`, followed by `wash build`, followed by starting and linking the actor on a wasmcloud host and confirming that the actor echos requests over NATS back as a response

Signed-off-by: Connor Smith <connor@cosmonic.com>