### PR TITLE
change target back to wasm32-unknown-unknown

### DIFF
--- a/actor/echo-messaging/.cargo/config.toml
+++ b/actor/echo-messaging/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "wasm32-wasi"
+target = "wasm32-unknown-unknown"

--- a/actor/echo-messaging/wasmcloud.toml
+++ b/actor/echo-messaging/wasmcloud.toml
@@ -5,4 +5,4 @@ version = "0.1.0"
 
 [actor]
 claims = ["wasmcloud:messaging"]
-wasm_target = "wasm32-wasi"
+wasm_target = "wasm32-unknown-unknown"


### PR DESCRIPTION
This reverts the echo-messaging template to use `wasm32-uknown-uknown`, so we don't run into backwards incompatibility issues

Signed-off-by: Connor Smith <connor@cosmonic.com>