### PR TITLE
Bump/wasmbus rpc

### DIFF
--- a/actor/echo-messaging/Cargo.toml
+++ b/actor/echo-messaging/Cargo.toml
@@ -11,8 +11,8 @@ name = "{{to_snake_case project-name}}"
 [dependencies]
 futures = "0.3"
 serde_json = "1.0"
-wasmbus-rpc = "0.11"
-wasmcloud-interface-messaging = "0.8"
+wasmbus-rpc = "0.13"
+wasmcloud-interface-messaging = "0.9"
 
 [profile.release]
 # Optimize for small code size

--- a/actor/echo-messaging/Makefile
+++ b/actor/echo-messaging/Makefile
@@ -4,7 +4,7 @@ PROJECT  = {{to_snake_case project-name}}
 VERSION  = $(shell cargo metadata --no-deps --format-version 1 | jq -r '.packages[] .version' | head -1)
 REVISION = 0
 # list of all contract claims for actor signing (space-separated)
-CLAIMS   = wasmcloud:httpserver
+CLAIMS   = wasmcloud:messaging
 # registry url for our actor
 REG_URL  = localhost:5000/v2/$(PROJECT):$(VERSION)
 # command to upload to registry (without last wasm parameter)

--- a/actor/echo/Cargo.toml
+++ b/actor/echo/Cargo.toml
@@ -11,8 +11,8 @@ name = "{{to_snake_case project-name}}"
 [dependencies]
 futures = "0.3"
 serde_json = "1.0"
-wasmbus-rpc = "0.11"
-wasmcloud-interface-httpserver = "0.8"
+wasmbus-rpc = "0.13"
+wasmcloud-interface-httpserver = "0.10"
 
 [profile.release]
 # Optimize for small code size

--- a/actor/hello/Cargo.toml
+++ b/actor/hello/Cargo.toml
@@ -11,8 +11,8 @@ name = "{{to_snake_case project-name}}"
 [dependencies]
 futures = "0.3"
 form_urlencoded = "1.0"
-wasmbus-rpc = "0.11"
-wasmcloud-interface-httpserver = "0.8"
+wasmbus-rpc = "0.13"
+wasmcloud-interface-httpserver = "0.10"
 
 [profile.release]
 # Optimize for small code size

--- a/interface/converter-actor/rust/Cargo.toml
+++ b/interface/converter-actor/rust/Cargo.toml
@@ -16,12 +16,12 @@ crate-type = ["cdylib", "rlib"]
 async-trait = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11.5"
-wasmbus-rpc = "0.11"
+wasmbus-rpc = "0.13"
 
 [dev-dependencies]
 base64 = "0.13"
 
 # build-dependencies needed for build.rs
 [build-dependencies]
-weld-codegen = "0.6"
+weld-codegen = "0.7"
 

--- a/interface/factorial/rust/Cargo.toml
+++ b/interface/factorial/rust/Cargo.toml
@@ -16,12 +16,12 @@ crate-type = ["cdylib", "rlib"]
 async-trait = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11.5"
-wasmbus-rpc = "0.11"
+wasmbus-rpc = "0.13"
 
 [dev-dependencies]
 base64 = "0.13"
 
 # build-dependencies needed for build.rs
 [build-dependencies]
-weld-codegen = "0.6"
+weld-codegen = "0.7"
 

--- a/provider/factorial/Cargo.toml
+++ b/provider/factorial/Cargo.toml
@@ -7,13 +7,13 @@ resolver = "2"
 [dependencies]
 async-trait = "0.1"
 tracing = "0.1.37"
-wasmbus-rpc = "0.11"
-wasmcloud-interface-factorial = "0.7"
-wasmcloud-interface-httpserver = "0.9"
+wasmbus-rpc = { version = "0.13", features = ["otel"] }
+wasmcloud-interface-factorial = "0.8"
+wasmcloud-interface-httpserver = "0.10"
 
 # test dependencies
 [dev-dependencies]
-wasmcloud-test-util = "0.6"
+wasmcloud-test-util = "0.8"
 tokio = { version = "1", features = [ "full" ] }
 
 [[bin]]

--- a/provider/messaging/Cargo.toml
+++ b/provider/messaging/Cargo.toml
@@ -9,12 +9,12 @@ async-trait = "0.1"
 futures = "0.3"
 serde = {version = "1.0", features = ["derive"] }
 tracing = "0.1.37"
-wasmbus-rpc = { version = "0.11", features = ["otel"] }
-wasmcloud-interface-messaging = "0.8"
+wasmbus-rpc = { version = "0.13", features = ["otel"] }
+wasmcloud-interface-messaging = "0.9"
 
 # test dependencies
 [dev-dependencies]
-wasmcloud-test-util = "0.5.0"
+wasmcloud-test-util = "0.8"
 
 [[bin]]
 name = "{{to_snake_case project-name}}"


### PR DESCRIPTION
This bumps all the project templates to wasmbus-rpc v0.13

I also fixed the claims in the echo-messaging makefile

Tested with wash pointed at this branch with the following templates and confirmed all built and the actor and provider worked in a host:
- echo-messaging actor
- messaging provider
- factorial interface