### PR TITLE
Added wadm manifests for examples

### DIFF
--- a/actor/echo-messaging/wadm.yaml
+++ b/actor/echo-messaging/wadm.yaml
@@ -1,0 +1,34 @@
+# This is a full example of how to run the echo messaging actor connected to NATS, listening on `wasmcloud.echo`
+# This example requires you to have WADM running: https://github.com/wasmCloud/wadm/. You
+# can deploy this example with a simple command:
+#
+# `wash app deploy wadm.yaml`
+
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: echo-messaging
+  annotations:
+    version: v0.0.1
+    description: "wasmCloud Echo Messaging Example"
+spec:
+  components:
+    - name: echo messaging
+      type: actor
+      properties:
+        image: wasmcloud.azurecr.io/echo_messaging:0.1.7
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 1
+        - type: linkdef
+          properties:
+            target: messaging
+            values:
+              SUBSCRIPTION: wasmcloud.echo
+
+    - name: messaging
+      type: capability
+      properties:
+        image: wasmcloud.azurecr.io/nats_messaging:0.17.0
+        contract: wasmcloud:messaging

--- a/actor/echo-tinygo/wadm.yaml
+++ b/actor/echo-tinygo/wadm.yaml
@@ -1,0 +1,33 @@
+# This is a full example of how to run the echo actor exposed with an HTTP server. Using this
+# example requires you to have WADM running: https://github.com/wasmCloud/wadm/.
+#
+# To run this example, use: `wash app deploy wadm.yaml`
+
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: echo-tinygo
+  annotations:
+    version: v0.0.1
+    description: "wasmCloud Echo Tinygo Example"
+spec:
+  components:
+    - name: hello
+      type: actor
+      properties:
+        image: wasmcloud.azurecr.io/echo:0.3.8
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 1
+        - type: linkdef
+          properties:
+            target: httpserver
+            values:
+              address: 0.0.0.0:8080
+
+    - name: httpserver
+      type: capability
+      properties:
+        image: wasmcloud.azurecr.io/httpserver:0.17.0
+        contract: wasmcloud:httpserver

--- a/actor/hello/wadm.yaml
+++ b/actor/hello/wadm.yaml
@@ -1,0 +1,33 @@
+# This is a full example of how to run the echo actor exposed with an HTTP server. Using this
+# example requires you to have WADM running: https://github.com/wasmCloud/wadm/.
+#
+# To run this example, use: `wash app deploy wadm.yaml`
+
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: hello
+  annotations:
+    version: v0.0.1
+    description: "wasmCloud Hello World Example"
+spec:
+  components:
+    - name: hello
+      type: actor
+      properties:
+        image: wasmcloud.azurecr.io/hello:0.1.7
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 1
+        - type: linkdef
+          properties:
+            target: httpserver
+            values:
+              address: 0.0.0.0:8080
+
+    - name: httpserver
+      type: capability
+      properties:
+        image: wasmcloud.azurecr.io/httpserver:0.17.0
+        contract: wasmcloud:httpserver

--- a/actor/kvcounter/wadm.yaml
+++ b/actor/kvcounter/wadm.yaml
@@ -1,0 +1,46 @@
+# This is a full example of how to run the kvcounter actor exposed with an HTTP server. Using this
+# example requires you to have a Redis server running locally (though the linkdef can be modified to
+# use a Redis server you have running elsewhere) and WADM running:
+#
+# https://github.com/wasmCloud/wadm/. You can deploy this example with a simple command:
+#
+# `wash app deploy wadm.yaml`
+
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: kvcounter
+  annotations:
+    version: v0.0.1
+    description: "wasmCloud Key Value Counter Example"
+spec:
+  components:
+    - name: kvcounter
+      type: actor
+      properties:
+        image: wasmcloud.azurecr.io/kvcounter:0.4.2
+      traits:
+        - type: spreadscaler
+          properties:
+            replicas: 1
+        - type: linkdef
+          properties:
+            target: redis
+            values:
+              URL: redis://127.0.0.1:6379/
+        - type: linkdef
+          properties:
+            target: httpserver
+            values:
+              ADDRESS: 0.0.0.0:8081
+
+    - name: httpserver
+      type: capability
+      properties:
+        image: wasmcloud.azurecr.io/httpserver:0.17.0
+        contract: wasmcloud:httpserver
+    - name: redis
+      type: capability
+      properties:
+        image: wasmcloud.azurecr.io/kvredis:0.21.0
+        contract: wasmcloud:keyvalue


### PR DESCRIPTION
## Feature or Problem
As of wash v0.18.0, wadm is included by default! I wanted to include these templates so people always have a starting point for wadm manifests.

## Related Issues
N/A

## Release Information
N/A

## Consumer Impact
Each template includes a `wadm.yaml` that users can run `wash app deploy` on.

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
