### PR TITLE
fix(*): upgrade wasmbus-rpc, specify wasm_target

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,0 @@
-[build]
-target = "wasm32-unknown-unknown"

--- a/actor/echo-httpserver-preview2/.github/workflows/release.yml
+++ b/actor/echo-httpserver-preview2/.github/workflows/release.yml
@@ -25,8 +25,8 @@ jobs:
 
       - uses: wasmcloud/common-actions/install-wash@main
 
-      - name: Add wasm32-unknown-unknown
-        run: rustup target add wasm32-unknown-unknown
+      - name: Add wasm32-wasi
+        run: rustup target add wasm32-wasi
 
       # Once you've written unit tests for your actor, you can uncomment
       # the two lines below to automatically run tests

--- a/actor/echo-messaging/.cargo/config.toml
+++ b/actor/echo-messaging/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "wasm32-unknown-unknown"
+target = "wasm32-wasi"

--- a/actor/echo-messaging/.github/workflows/build.yml
+++ b/actor/echo-messaging/.github/workflows/build.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Add wasm32-unknown-unknown
-        run: rustup target add wasm32-unknown-unknown
+      - name: Add wasm32-wasi
+        run: rustup target add wasm32-wasi
       - name: Check formatting
         run: cargo fmt -- --check
         shell: bash

--- a/actor/echo-messaging/.github/workflows/release.yml
+++ b/actor/echo-messaging/.github/workflows/release.yml
@@ -20,8 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: wasmcloud/common-actions/install-wash@main
-      - name: Add wasm32-unknown-unknown
-        run: rustup target add wasm32-unknown-unknown
+      - name: Add wasm32-wasi
+        run: rustup target add wasm32-wasi
       # Once you've written unit tests for your actor, you can uncomment
       # the two lines below to automatically run tests
       # - name: Test actor

--- a/actor/echo-messaging/Cargo.toml
+++ b/actor/echo-messaging/Cargo.toml
@@ -11,8 +11,8 @@ name = "{{to_snake_case project-name}}"
 [dependencies]
 futures = "0.3"
 serde_json = "1.0"
-wasmbus-rpc = "0.14"
-wasmcloud-interface-messaging = "0.10"
+wasmbus-rpc = "0.15"
+wasmcloud-interface-messaging = "0.11"
 
 [profile.release]
 # Optimize for small code size

--- a/actor/echo-messaging/wasmcloud.toml
+++ b/actor/echo-messaging/wasmcloud.toml
@@ -5,3 +5,4 @@ version = "0.1.0"
 
 [actor]
 claims = ["wasmcloud:messaging"]
+wasm_target = "wasm32-unknown-unknown"

--- a/actor/echo-messaging/wasmcloud.toml
+++ b/actor/echo-messaging/wasmcloud.toml
@@ -5,4 +5,4 @@ version = "0.1.0"
 
 [actor]
 claims = ["wasmcloud:messaging"]
-wasm_target = "wasm32-unknown-unknown"
+wasm_target = "wasm32-wasi-preview1"

--- a/actor/echo-tinygo/wasmcloud.toml
+++ b/actor/echo-tinygo/wasmcloud.toml
@@ -5,4 +5,4 @@ version = "0.1.0"
 
 [actor]
 claims = ["wasmcloud:httpserver"]
-wasm_target = "wasm32-unknown-unknown"
+wasm_target = "wasm32-wasi-preview1"

--- a/actor/echo-tinygo/wasmcloud.toml
+++ b/actor/echo-tinygo/wasmcloud.toml
@@ -5,3 +5,4 @@ version = "0.1.0"
 
 [actor]
 claims = ["wasmcloud:httpserver"]
+wasm_target = "wasm32-unknown-unknown"

--- a/actor/hello/.cargo/config.toml
+++ b/actor/hello/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "wasm32-unknown-unknown"
+target = "wasm32-wasi"

--- a/actor/hello/.github/workflows/build.yml
+++ b/actor/hello/.github/workflows/build.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Add wasm32-unknown-unknown
-        run: rustup target add wasm32-unknown-unknown
+      - name: Add wasm32-wasi
+        run: rustup target add wasm32-wasi
       - name: Check formatting
         run: cargo fmt -- --check
         shell: bash

--- a/actor/hello/.github/workflows/release.yml
+++ b/actor/hello/.github/workflows/release.yml
@@ -20,8 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: wasmcloud/common-actions/install-wash@main
-      - name: Add wasm32-unknown-unknown
-        run: rustup target add wasm32-unknown-unknown
+      - name: Add wasm32-wasi
+        run: rustup target add wasm32-wasi
       # Once you've written unit tests for your actor, you can uncomment
       # the two lines below to automatically run tests
       # - name: Test actor

--- a/actor/hello/Cargo.toml
+++ b/actor/hello/Cargo.toml
@@ -10,8 +10,8 @@ name = "{{to_snake_case project-name}}"
 
 [dependencies]
 futures = "0.3"
-wasmbus-rpc = "0.14"
-wasmcloud-interface-httpserver = "0.11"
+wasmbus-rpc = "0.15"
+wasmcloud-interface-httpserver = "0.12"
 
 [profile.release]
 # Optimize for small code size

--- a/actor/hello/wasmcloud.toml
+++ b/actor/hello/wasmcloud.toml
@@ -5,4 +5,4 @@ version = "0.1.0"
 
 [actor]
 claims = ["wasmcloud:httpserver"]
-wasm_target = "wasm32-unknown-unknown"
+wasm_target = "wasm32-wasi-preview1"

--- a/actor/hello/wasmcloud.toml
+++ b/actor/hello/wasmcloud.toml
@@ -5,3 +5,4 @@ version = "0.1.0"
 
 [actor]
 claims = ["wasmcloud:httpserver"]
+wasm_target = "wasm32-unknown-unknown"

--- a/actor/kvcounter/.cargo/config.toml
+++ b/actor/kvcounter/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = "wasm32-unknown-unknown"
+target = "wasm32-wasi"

--- a/actor/kvcounter/.github/workflows/build.yml
+++ b/actor/kvcounter/.github/workflows/build.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Add wasm32-unknown-unknown
-        run: rustup target add wasm32-unknown-unknown
+      - name: Add wasm32-wasi
+        run: rustup target add wasm32-wasi
       - name: Check formatting
         run: cargo fmt -- --check
         shell: bash

--- a/actor/kvcounter/.github/workflows/release.yml
+++ b/actor/kvcounter/.github/workflows/release.yml
@@ -20,8 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: wasmcloud/common-actions/install-wash@main
-      - name: Add wasm32-unknown-unknown
-        run: rustup target add wasm32-unknown-unknown
+      - name: Add wasm32-wasi
+        run: rustup target add wasm32-wasi
       # Once you've written unit tests for your actor, you can uncomment
       # the two lines below to automatically run tests
       # - name: Test actor

--- a/actor/kvcounter/Cargo.toml
+++ b/actor/kvcounter/Cargo.toml
@@ -15,9 +15,9 @@ serde_bytes = "0.11"
 serde_json ="1.0"
 serde = {version = "1.0", features = ["derive"]}
 
-wasmbus-rpc = "0.14"
-wasmcloud-interface-keyvalue = "0.11"
-wasmcloud-interface-httpserver = "0.11"
+wasmbus-rpc = "0.15"
+wasmcloud-interface-keyvalue = "0.12"
+wasmcloud-interface-httpserver = "0.12"
 
 [profile.release]
 # Optimize for small code size

--- a/actor/kvcounter/wasmcloud.toml
+++ b/actor/kvcounter/wasmcloud.toml
@@ -5,3 +5,4 @@ version = "0.1.0"
 
 [actor]
 claims = ["wasmcloud:httpserver", "wasmcloud:keyvalue"]
+wasm_target = "wasm32-unknown-unknown"

--- a/actor/kvcounter/wasmcloud.toml
+++ b/actor/kvcounter/wasmcloud.toml
@@ -5,4 +5,4 @@ version = "0.1.0"
 
 [actor]
 claims = ["wasmcloud:httpserver", "wasmcloud:keyvalue"]
-wasm_target = "wasm32-unknown-unknown"
+wasm_target = "wasm32-wasi-preview1"

--- a/interface/converter-actor/rust/Cargo.toml
+++ b/interface/converter-actor/rust/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "rlib"]
 async-trait = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11.5"
-wasmbus-rpc = "0.14"
+wasmbus-rpc = "0.15"
 
 [dev-dependencies]
 base64 = "0.13"

--- a/interface/factorial/rust/Cargo.toml
+++ b/interface/factorial/rust/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "rlib"]
 async-trait = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11.5"
-wasmbus-rpc = "0.14"
+wasmbus-rpc = "0.15"
 
 [dev-dependencies]
 base64 = "0.13"

--- a/provider/factorial/Cargo.toml
+++ b/provider/factorial/Cargo.toml
@@ -7,9 +7,9 @@ resolver = "2"
 [dependencies]
 async-trait = "0.1"
 tracing = "0.1.37"
-wasmbus-rpc = { version = "0.14", features = ["otel"] }
-wasmcloud-interface-factorial = "0.9"
-wasmcloud-interface-httpserver = "0.11"
+wasmbus-rpc = { version = "0.15", features = ["otel"] }
+wasmcloud-interface-factorial = "0.10"
+wasmcloud-interface-httpserver = "0.12"
 
 # test dependencies
 [dev-dependencies]

--- a/provider/messaging/Cargo.toml
+++ b/provider/messaging/Cargo.toml
@@ -9,8 +9,8 @@ async-trait = "0.1"
 futures = "0.3"
 serde = {version = "1.0", features = ["derive"] }
 tracing = "0.1.37"
-wasmbus-rpc = { version = "0.14", features = ["otel"] }
-wasmcloud-interface-messaging = "0.10"
+wasmbus-rpc = { version = "0.15", features = ["otel"] }
+wasmcloud-interface-messaging = "0.11"
 
 # test dependencies
 [dev-dependencies]


### PR DESCRIPTION
## Feature or Problem
This PR fixes our current templates that depend on wasmbus_rpc to upgrade to 0.15 and their related dependent interfaces.

Additionally, specifying the `wasm_target` in wasmcloud.toml protects us from defaulting in the future to components in wash build and breaking builds of module targets.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
N/A

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
I tested with `wash new` to verify that `wasm32-wasi` and `wasm32-wasi-preview1` were the correct targets for building our module actors.
