### PR TITLE
fix(go/echo-tinygo): remove default wasm_target

### DIFF
--- a/actor/echo-tinygo/wasmcloud.toml
+++ b/actor/echo-tinygo/wasmcloud.toml
@@ -5,4 +5,3 @@ version = "0.1.0"
 
 [actor]
 claims = ["wasmcloud:httpserver"]
-wasm_target = "wasm32-wasi-preview1"


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

While we updated the default target to `wasm32-wasi-preview1`, current `wash` builds expect that preview1/preview2 components are WIT-first, and attempt to run bindgen on them.

`echo-tinygo` is *not* WIT-powered, and uses the legacy smithy interface, which is fine as we are backwards compatible, *but* raises a problem when `wash` attempts to run bindgen.

This problem was discovered upstream:
https://github.com/wasmCloud/wasmCloud/issues/1241

This commit returns the `wasm_target` default to
`wasm32-unknown-unknown`, in anticipation that an upstream change to `wash` is merged which does a more stringent check.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
